### PR TITLE
Issue #2685809 - Replace deprecated DB functions

### DIFF
--- a/modules/commerce_stock_dev/src/Form/stock_dev_form.php
+++ b/modules/commerce_stock_dev/src/Form/stock_dev_form.php
@@ -282,7 +282,7 @@ class stock_dev_form extends ConfigFormBase {
     $location_ids = explode(',', $form_state->getValue('location_ids'));
     // Call the API
     $stock_api = new StockStorageAPI;
-    $stock_level = $stock_api->getStockLevel($prod_id, $location_ids);
+    $stock_level = $stock_api->getTotalStockLevel($prod_id, $location_ids);
     drupal_set_message(t('Stock level is: @stock_level', ['@stock_level' => $stock_level]));
 
     // $stock_api->createTransaction(1, 1, '', 1, 0.0);
@@ -326,7 +326,7 @@ class stock_dev_form extends ConfigFormBase {
     $location_id = $form_state->getValue('location');
 
     $stock_api = new StockStorageAPI;
-    $stock_api->updateProductInventoryLocationLevel($location_id, $variation_id);
+    $stock_api->updateLocationStockLevel($location_id, $variation_id);
   }
 
   public function submitStockAvailabilityCheck(array &$form, FormStateInterface $form_state) {

--- a/modules/storage/commerce_stock_s.install
+++ b/modules/storage/commerce_stock_s.install
@@ -238,8 +238,9 @@ function commerce_stock_s_schema() {
  * Implements hook_install().
  */
 function commerce_stock_s_install() {
-  // Add primery stock location.
-  db_insert('cs_inventory_location')
+  $db = \Drupal::database();
+  // Add primary stock location.
+  $db->insert('cs_inventory_location')
     ->fields([
       'name' => 'Main',
       'status' => 1,
@@ -247,14 +248,14 @@ function commerce_stock_s_install() {
     ->execute();
 
   // Add core transaction types.
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 1,
       'name' => 'Stock in',
       'parent_ttid' => 1,
     ])
     ->execute();
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 2,
       'name' => 'Stock Out',
@@ -262,35 +263,35 @@ function commerce_stock_s_install() {
     ])
     ->execute();
   // Add sub transaction types.
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 4,
       'name' => 'Sale',
       'parent_ttid' => 2,
     ])
     ->execute();
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 5,
       'name' => 'Return',
       'parent_ttid' => 1,
     ])
     ->execute();
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 6,
       'name' => 'New Stock',
       'parent_ttid' => 1,
     ])
     ->execute();
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 7,
       'name' => 'Move From',
       'parent_ttid' => 2,
     ])
     ->execute();
-  db_insert('cs_inventory_transaction_type')
+  $db->insert('cs_inventory_transaction_type')
     ->fields([
       'ttid' => 8,
       'name' => 'Move To',

--- a/modules/storage/src/Plugin/QueueWorker/StockWorkerLocationLevel.php
+++ b/modules/storage/src/Plugin/QueueWorker/StockWorkerLocationLevel.php
@@ -27,7 +27,7 @@ class StockWorkerLocationLevel extends QueueWorkerBase {
     // Update.
     foreach ($locations as $location_id => $location) {
       // Update the stock level.
-      $stock_api->updateProductInventoryLocationLevel($location_id, $data);
+      $stock_api->updateLocationStockLevel($location_id, $data);
     }
   }
 

--- a/modules/storage/src/StockStorageAPI.php
+++ b/modules/storage/src/StockStorageAPI.php
@@ -21,180 +21,200 @@ class StockStorageAPI implements StockCheckInterface, StockUpdateInterface {
     $data = isset($metadata['data']) ? $metadata['data'] : NULL;
 
     // Create a record.
-    // @todo - Deprecated replace with https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Connection.php/function/Connection%3A%3Ainsert/8
-    $io = db_insert('cs_inventory_transaction');
-    $io->fields([
-      'variation_id',
-      'qty',
-      'location_id',
-      'location_zone',
-      'unit_cost',
-      'transaction_time',
-      'transaction_type_id',
-      'related_tid',
-      'related_oid',
-      'related_uid',
-      'data',
-    ]);
-    $io->values([
-      $variation_id,
-      $quantity,
-      $location_id,
-      $zone,
-      $unit_cost,
-      time(),
-      $transaction_type_id,
-      $related_tid,
-      $related_oid,
-      $related_uid,
-      serialize($data),
-    ]);
-    return $io->execute();
+    $field_values = [
+      'variation_id' => $variation_id,
+      'qty' => $quantity,
+      'location_id' => $location_id,
+      'location_zone' => $zone,
+      'unit_cost' => $unit_cost,
+      'transaction_time' => time(),
+      'transaction_type_id' => $transaction_type_id,
+      'related_tid' => $related_tid,
+      'related_oid' => $related_oid,
+      'related_uid' => $related_uid,
+      'data' => serialize($data),
+    ];
+    $insert = \Drupal::database()->insert('cs_inventory_transaction')
+      ->fields(array_keys($field_values))
+      ->values(array_values($field_values))->execute();
+
+    return $insert;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function updateProductInventoryLocationLevel($location_id, $variation_id) {
-    // Get the location level & last transaction.
+  public function updateLocationStockLevel($location_id, $variation_id) {
+    $current_level = $this->getLocationStockLevel($location_id, $variation_id);
+    $last_update = $current_level['last_transaction'];
+    $latest_txn = $this->getLocationStockTransactionLatest($location_id, $variation_id);
+    $latest_sum = $this->getLocationStockTransactionSum($location_id, $variation_id, $last_update, $latest_txn);
+    $new_level = $current_level['qty'] + $latest_sum;
+
+    $this->setLocationStockLevel($location_id, $variation_id, $new_level, $latest_txn);
+  }
+
+  /**
+   * Gets stock level for a given location and variation.
+   *
+   * @param $location_id
+   *   Location id.
+   *
+   * @param $variation_id
+   *   Variation id.
+   *
+   * @return array
+   *   An array of 'qty' and 'last_transaction_id' values.
+   */
+  public function getLocationStockLevel($location_id, $variation_id) {
     $db = \Drupal::database();
     $result = $db->select('cs_inventory_location_level', 'ill')
       ->fields('ill')
-      ->condition('location_id', $location_id, '=')
+      ->condition('location_id', $location_id)
       ->condition('variation_id', $variation_id)
       ->execute()
       ->fetch();
-    if ($result) {
-      $stock_level = $result->qty;
-      $last_transaction = $result->last_transaction_id;
+
+    return [
+      'qty' => $result ? $result->qty : 0,
+      'last_transaction' => $result ? $result->last_transaction_id : 0
+    ];
+  }
+
+  /**
+   * Sets the stock level and last transaction for a given location and variation.
+   *
+   * Creates first stock level transaction record if none exists.
+   *
+   * @param int $location_id
+   *   Location id.
+   *
+   * @param int $variation_id
+   *   Variation id.
+   *
+   * @param int $qty
+   *   Quantity.
+   *
+   * @param int $last_txn
+   *   Last transaction id.
+   */
+  public function setLocationStockLevel($location_id, $variation_id, $qty, $last_txn) {
+    $db = \Drupal::database();
+    $existing = $db->select('cs_inventory_location_level', 'ill')
+      ->fields('ill')
+      ->condition('location_id', $location_id)
+      ->condition('variation_id', $variation_id)
+      ->execute();
+    if ($existing) {
+      $db->update('cs_inventory_location_level')
+        ->fields([
+          'qty' => $qty,
+          'last_transaction_id' => $last_txn,
+        ])
+        ->condition('location_id', $location_id, '=')
+        ->condition('variation_id', $variation_id, '=')
+        ->execute();
     }
     else {
-      $stock_level = 0;
-      $last_transaction = 0;
-      // Create a record.
-      // @todo - Deprecated replace with https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Database%21Connection.php/function/Connection%3A%3Ainsert/8
-      $io = db_insert('cs_inventory_location_level');
-      $io->fields([
-        'location_id',
-        'variation_id',
-        'qty',
-        'last_transaction_id',
-      ]);
-      $io->values([$location_id, $variation_id, 0, 0]);
-      $io->execute();
+      $db->insert('cs_inventory_location_level')
+        ->fields(['location_id', 'variation_id', 'qty', 'last_transaction_id'])
+        ->values([$location_id, $variation_id, 0, 0])
+        ->execute();
     }
+  }
 
-    // Get the last transaction id.
-    // @todo - need to use a higher level method.
-    $query = "select max(trid) as max_id from `{cs_inventory_transaction}`
-      WHERE (`location_id` = '" . $location_id . "')
-      AND (`variation_id` =" . $variation_id . ")
-      GROUP BY location_id";
-    $result = $db->query($query)->fetch();
-    if (!$result) {
-      // If no new transaction then nothing to do.
-      return;
-    }
-    $max_transaction = $result->max_id;
+  /**
+   * Gets the last transaction id for a given location and variation.
+   *
+   * @param $location_id
+   *   Location id.
+   *
+   * @param $variation_id
+   *   Product variation id.
+   *
+   * @return int
+   *   The last location stock transaction id.
+   */
+  public function getLocationStockTransactionLatest($location_id, $variation_id) {
+    $db = \Drupal::database();
+    $query = $db->select('cs_inventory_transaction')
+      ->condition('location_id', $location_id)
+      ->condition('variation_id', $variation_id);
+    $query->addExpression('MAX(trid)', 'max_id');
+    $query->groupBy('location_id');
+    $result = $query
+      ->execute()
+      ->fetch();
 
-    // Total all transactions between last and max transactions.
-    // @todo - need to use a higher level method.
-    $query = "SELECT location_id, sum(qty) as transactions_qty FROM `{cs_inventory_transaction}`
-      WHERE (`location_id` = '" . $location_id . "')
-      AND (`variation_id` =" . $variation_id . ")
-      AND (`trid` > " . $last_transaction . ")
-      AND (`trid` <= " . $max_transaction . ")
-      GROUP BY location_id";
-    $result = $db->query($query)->fetch();
-    if ($result) {
-      // Add the transactions qty to the existing location level.
-      $stock_level += $result->transactions_qty;
-      // @todo - use non Deprecated function.
-      $io = db_update('cs_inventory_location_level');
-      $io->fields([
-        'qty' => $stock_level,
-        'last_transaction_id' => $max_transaction,
-      ]);
-      $io->condition('location_id', $location_id, '=');
-      $io->condition('variation_id', $variation_id, '=');
-      $io->execute();
+    return $result ? $result->max_id : 0;
+  }
+
+  /**
+   * Gets the sum of all stock transactions between a range of transactions.
+   */
+  public function getLocationStockTransactionSum($location_id, $variation_id, $min, $max) {
+    $db = \Drupal::database();
+    $query = $db->select('cs_inventory_transaction', 'it')
+      ->fields('it', ['location_id'])
+      ->condition('location_id', $location_id)
+      ->condition('variation_id', $variation_id)
+      ->condition('trid', $min, '>');
+    if ($max) {
+      $query->condition('trid', $max, '<=');
     }
+    $query->addExpression('SUM(qty)', 'qty');
+    $query->groupBy('location_id');
+    $result = $query->execute()
+      ->fetch();
+
+    return $result ? $result->qty : 0;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function getStockLevel($variation_id, array $locations) {
-    /** @var array $location_info */
-    $location_info = $this->getStockLocationLevel($variation_id, $locations);
-    // Add the quantities together and return.
-    $qty = 0;
+  public function getTotalStockLevel($variation_id, array $locations) {
+    $location_info = $this->getLocationsStockLevels($variation_id, $locations);
+    $total = 0;
     foreach ($location_info as $location) {
-      $qty += $location['qty'] + $location['transactions_qty'];
+      $total += $location['qty'];
     }
-    return $qty;
+
+    return $total;
   }
 
   /**
-   * Gets the stock location level.
+   * Gets the stock levels for a set of locations.
    *
    * @param int $variation_id
-   *   The product variation ID.
-   * @param array $locations
-   *   Array of locations.
+   *   The product variation id.
    *
-   * @return array The stock location level.
-   *   The stock location level.
+   * @param array $locations
+   *   Array of locations ids.
+   *
+   * @return array
+   *   Stock level information indexed by location id with these values:
+   *     - 'qty': The quantity.
+   *     - 'last_transaction': The id of the last transaction.
    */
-  public function getStockLocationLevel($variation_id, array $locations) {
-    // An array to hold stock data for the listed locations.
-    $location_info = [];
+  public function getLocationsStockLevels($variation_id, array $locations) {
+    $location_levels = [];
     foreach ($locations as $location_id) {
-      $location_info[$location_id] = [
-        'qty' => 0,
-        'last_transaction' => 0,
-        'transactions_qty' => 0,
+      $location_level = $this->getLocationStockLevel($location_id, $variation_id);
+      $location_levels[$location_id] = [
+        'qty' => $location_level['qty'],
+        'last_transaction' => $location_level['last_transaction'],
       ];
     }
 
-    // Get the location level & last transaction.
-    $db = \Drupal::database();
-    $result = $db->select('cs_inventory_location_level', 'ill')
-      ->fields('ill')
-      ->condition('location_id', $locations, 'IN')
-      ->condition('variation_id', $variation_id)
-      ->execute()
-      ->fetchAll();
-    if ($result) {
-      foreach ($result as $record) {
-        // Location info for retriving transactions.
-        $location_info[$record->location_id]['qty'] = $record->qty;
-        $location_info[$record->location_id]['last_transaction'] = $record->last_transaction_id;
-
-      }
-    }
-
-    // Cycle all locations to toal the transactions.
-    foreach ($location_info as $location_id => $location) {
-      // @todo - need to use a higher level method, the select below for details
-      $query = "SELECT location_id, sum(qty) as transactions_qty FROM `{cs_inventory_transaction}`
-      WHERE (`location_id` = '" . $location_id . "')
-      AND (`variation_id` =" . $variation_id . ")
-      AND (`trid` > " . $location['last_transaction'] . ")
-      GROUP BY location_id";
-      $result = $db->query($query)->fetch();
-      if ($result) {
-        $location_info[$location_id]['transactions_qty'] = $result->transactions_qty;
-      }
-    }
-    return $location_info;
+    return $location_levels;
   }
 
   /**
    * {@inheritdoc}
    */
   public function getIsInStock($variation_id, $locations) {
-    return ($this->getStockLevel($variation_id, $locations) > 0);
+    return ($this->getTotalStockLevel($variation_id, $locations) > 0);
   }
 
   /**
@@ -219,26 +239,23 @@ class StockStorageAPI implements StockCheckInterface, StockUpdateInterface {
    * {@inheritdoc}
    */
   public function getLocationList($return_active_only = TRUE) {
-    // Build the query.
     $db = \Drupal::database();
-    $query = $db->select('cs_inventory_location', 'il')->fields('il');
-    // If only active locations.
+    $query = $db->select('cs_inventory_location', 'il')
+      ->fields('il');
     if ($return_active_only) {
-      // Add a where condition.
       $query->condition('status', 1);
     }
-    // Run.
     $result = $query->execute()->fetchAll();
     $location_info = [];
     if ($result) {
       foreach ($result as $record) {
-        // Location info for retriving transactions.
         $location_info[$record->locid] = [
           'name' => $record->name,
           'status' => $record->status,
         ];
       }
     }
+
     return $location_info;
   }
 

--- a/src/AlwaysInStock.php
+++ b/src/AlwaysInStock.php
@@ -19,7 +19,7 @@ class AlwaysInStock implements StockCheckInterface, StockUpdateInterface {
   /**
    * {@inheritdoc}
    */
-  public function getStockLevel($variation_id, array $locations) {
+  public function getTotalStockLevel($variation_id, array $locations) {
     // @todo this can be configurable?
     return 999;
   }

--- a/src/StockAvailabilityChecker.php
+++ b/src/StockAvailabilityChecker.php
@@ -70,7 +70,7 @@ class StockAvailabilityChecker implements AvailabilityCheckerInterface {
     // Check if always in stock.
     if (!$stock_checker->getIsAlwaysInStock($variation_id)) {
       // Check if quantity is available.
-      $stock_level = $stock_checker->getStockLevel($variation_id, $locations);
+      $stock_level = $stock_checker->getTotalStockLevel($variation_id, $locations);
       return ($stock_level >= $quantity);
     }
     return TRUE;

--- a/src/StockCheckInterface.php
+++ b/src/StockCheckInterface.php
@@ -18,7 +18,7 @@ interface StockCheckInterface {
    * @return int The stock level.
    *   The stock level.
    */
-  public function getStockLevel($variation_id, array $locations);
+  public function getTotalStockLevel($variation_id, array $locations);
 
   /**
    * Check if product is in stock.

--- a/src/StockManager.php
+++ b/src/StockManager.php
@@ -240,7 +240,7 @@ class StockManager implements StockManagerInterface, StockTransactionsInterface 
         ->getStockChecker();
       // @todo - we need a better way to determin the locations.
       $locations = array_keys($stock_checker->getLocationList());
-      return $stock_checker->getStockLevel($variation_id, $locations);
+      return $stock_checker->getTotalStockLevel($variation_id, $locations);
 
     }
     else {


### PR DESCRIPTION
This cleans up the API and .install database calls.  Also cleaned up the API with tighter functions, re-using one once and making the names of the methods more intuitive.
